### PR TITLE
feat: Implement mock mode toggle and update video generation logic

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -24,7 +24,10 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "@angular/material/prebuilt-themes/rose-red.css",
+              "src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -112,7 +115,10 @@
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "@angular/material/prebuilt-themes/rose-red.css",
+              "src/styles.scss"
+            ],
             "scripts": []
           }
         }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^19.2.14",
+        "@angular/cdk": "^19.2.19",
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",
         "@angular/core": "^19.2.0",
         "@angular/fire": "^19.2.0",
         "@angular/forms": "^19.2.0",
+        "@angular/material": "^19.2.19",
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
@@ -508,6 +510,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "19.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.19.tgz",
+      "integrity": "sha512-PCpJagurPBqciqcq4Z8+3OtKLb7rSl4w/qBJoIMua8CgnrjvA1i+SWawhdtfI1zlY8FSwhzLwXV0CmWWfFzQPg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.15.tgz",
@@ -708,6 +725,23 @@
         "@angular/common": "19.2.14",
         "@angular/core": "19.2.14",
         "@angular/platform-browser": "19.2.14",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "19.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.19.tgz",
+      "integrity": "sha512-auIE6JUzTIA3LyYklh9J/T7u64crmphxUBgAa0zcOMDog6SYfwbNe9YeLQqua5ek4OUAOdK/BHHfVl5W5iaUoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "19.2.19",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "@angular/forms": "^19.0.0 || ^20.0.0",
+        "@angular/platform-browser": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -11956,7 +11990,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11997,7 +12030,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,11 +12,13 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^19.2.14",
+    "@angular/cdk": "^19.2.19",
     "@angular/common": "^19.2.0",
     "@angular/compiler": "^19.2.0",
     "@angular/core": "^19.2.0",
     "@angular/fire": "^19.2.0",
     "@angular/forms": "^19.2.0",
+    "@angular/material": "^19.2.19",
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,9 +8,11 @@
   <meta name="viewport"
     content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, shrink-to-fit=no">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 
-<body>
+<body class="mat-typography">
   <app-root></app-root>
 </body>
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -62,3 +62,6 @@ a,
 [role="button"] {
   touch-action: manipulation;
 }
+
+html, body { height: 100%; }
+body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
- Added endpoints to toggle mock mode and retrieve its status.
- Refactored mock video handling to use a simplified list of pre-selected video URIs.
- Enhanced the generate_video endpoint to return video URI directly in mock mode.
- Updated Angular frontend to integrate mock mode controls in the chat component, improving user interaction.